### PR TITLE
🩹 prevent patching longtable in acro package

### DIFF
--- a/acronyms.lua
+++ b/acronyms.lua
@@ -102,6 +102,7 @@ if FORMAT:match 'latex' then
   acronyms_header = function (acronyms)
     local tmpl = [[
 \usepackage{acro}
+\acsetup{patch/longtable=false}
 $for(acronyms)$
 \DeclareAcronym{$acronyms.id$}{
   $for(acronyms.properties/pairs)$$it.key$ = $it.value$$sep$,


### PR DESCRIPTION
So far, rendering to latex when using the lua filter results in this error:

```
compilation failed- error
Package acro Error: Patching `longtable' failed. Please contact the acro
(acro)                author.
```
Inserting the suggested line of code fixes the error for me. I found it here: https://github.com/cgnieder/acro/issues/252
