### PR TITLE
Add docx output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+
+# output
+*.docx
+*.pdf
+*.html

--- a/acronyms.lua
+++ b/acronyms.lua
@@ -141,6 +141,18 @@ elseif FORMAT:match 'html' then
       render_acronym_span(id, acro, uppercase).content ..
       {pandoc.RawInline('html', '</abbr>')}
   end
+
+-- adapt for Word docx
+elseif FORMAT:match 'docx' then
+  render_acronym = function (id, acro, uppercase)
+    if not acro.seen then
+      return pandoc.Inlines{render_acronym_span(id, acro, uppercase)}
+    end
+
+   return {pandoc.Span(
+      render_acronym_span(id, acro, uppercase).content)
+      }
+  end
 end
 
 --

--- a/example.qmd
+++ b/example.qmd
@@ -1,0 +1,32 @@
+---
+author: Sarah
+format: 
+  docx: 
+    toc: true
+  pdf: 
+    toc: true
+  html: 
+    self-contained: true
+acronyms:
+  html:
+    short: HTML
+    long: hypertext markup language
+  css:
+    short: CSS
+    long: Cascading Style Sheets
+  amphetamine: alpha-methylphenethylamine
+filters: 
+  - acronyms.lua
+---
+
+  This page uses [[html]] and [[css]].
+
+It's also possible to use spans for acronyms, e.g., [css]{.acro}.
+
+Capitalize the acronym ID to uppercase the first letter of the
+replacement text: [[Amphetamine]].
+
+## Acronyms
+
+::: {#acronym-defs}
+:::


### PR DESCRIPTION
So far, the lua filter only renders to PDF and HTML. I added some lines to also render to `docx`. To showcase it, I also added an example `qmd` file. 